### PR TITLE
BUG Properly deprecate old 'memory' config setting

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,5 +1,7 @@
 <?php
 
+Deprecation::notification_version('1.3.0', 'sqlite3');
+
 $classes = array('SQLiteDatabase', 'SQLite3Database', 'SQLitePDODatabase');
 
 global $databaseConfig;

--- a/code/SQLite3Database.php
+++ b/code/SQLite3Database.php
@@ -63,6 +63,16 @@ class SQLite3Database extends SS_Database {
 	function connectDatabase() {
 		$this->enum_map = array();
 		$parameters = $this->parameters;
+		
+		if(!empty($parameters['memory'])) {
+			Deprecation::notice(
+				'1.4.0',
+				"\$databaseConfig['memory'] is deprecated. Use \$databaseConfig['path'] = ':memory:' instead.",
+				Deprecation::SCOPE_GLOBAL
+			);
+			$parameters['path'] = ':memory:';
+		}
+		
 		$dbName = !isset($this->database) ? $parameters['database'] : $this->database;
 		$file = $parameters['path'];
 

--- a/code/SQLitePDODatabase.php
+++ b/code/SQLitePDODatabase.php
@@ -13,6 +13,16 @@ class SQLitePDODatabase extends SQLite3Database {
 	function connectDatabase() {
 		$this->enum_map = array();
 		$parameters = $this->parameters;
+		
+		if(!empty($parameters['memory'])) {
+			Deprecation::notice(
+				'1.4.0',
+				"\$databaseConfig['memory'] is deprecated. Use \$databaseConfig['path'] = ':memory:' instead.",
+				Deprecation::SCOPE_GLOBAL
+			);
+			$parameters['path'] = ':memory:';
+		}
+		
 		$dbName = !isset($this->database) ? $parameters['database'] : $dbName=$this->database;
 		$file = $parameters['path'];
 


### PR DESCRIPTION
Recently the `$databaseConfig['memory']` option was removed, but there was missing a proper deprecation, meaning anyone using this in their code had it silently revert to using a file based connection.

This fix restores the original option, but with a deprecation message.

I assume that the target for this module is version 1.3, since 1.2 is SS 2.4 targetted.
