### PR TITLE
Update docs and alias dev-master as 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,73 @@
-SQLite3 Module
-==============
+# SQLite3 Module
 
 [![Build Status](https://travis-ci.org/silverstripe-labs/silverstripe-sqlite3.png?branch=master)](https://travis-ci.org/silverstripe-labs/silverstripe-sqlite3)
 
-Maintainer Contact
-------------------
+## Maintainer Contact
+
 Andreas Piening (Nickname: apiening)
 <andreas (at) silverstripe (dot) com>
 
+## Requirements
 
-Requirements
-------------
-SilverStripe 3.0 or newer
+ * SilverStripe 3.2 or newer
 
+## Installation
 
-Installation
-------------
-Download, unzip and copy the sqlite3 folder to your project root so that it becomes a sibling of `framework/`.
+ * If using composer, run `composer require silverstripe/sqlite3 1.4.*-dev`.
+ * Otherwise, download, unzip and copy the sqlite3 folder to your project root so that it becomes a
+   sibling of `framework/`.
 
-Either use the installer to automatically install SQLite or add this to your _config.php (right after "require_once("conf/ConfigureFromEnv.php");" if you are using _ss_environment.php)
+## Configuration
+
+Either use the installer to automatically install SQLite or add this to your _config.php (right after
+"require_once("conf/ConfigureFromEnv.php");" if you are using _ss_environment.php)
 
 	$databaseConfig['type'] = 'SQLiteDatabase';
 	$databaseConfig['path'] = "/path/to/my/database/file";
 
-Make sure the webserver has sufficient privileges to write to that folder and that it is protected from external access.
+Make sure the webserver has sufficient privileges to write to that folder and that it is protected from
+external access.
 
 
-Sample mysite/_config.php
--------------------------
+### Sample mysite/_config.php
 
-	<?php
+```php
+<?php
+global $project;
+$project = 'mysite';
 
-	global $project;
-	$project = 'mysite';
+global $database;
+$database = 'SS_mysite';
 
-	global $database;
-	$database = 'SS_mysite';
+require_once("conf/ConfigureFromEnv.php");
 
-	require_once("conf/ConfigureFromEnv.php");
+global $databaseConfig;
 
-	global $databaseConfig;
+$databaseConfig = array(
+	"type" => 'SQLiteDatabase',
+	"server" => 'none',
+	"username" => 'none',
+	"password" => 'none',
+	"database" => $database,
+	"path" => "/path/to/my/database/file",
+);
 
-	$databaseConfig = array(
-		"type" => 'SQLiteDatabase',
-		"server" => 'none',
-		"username" => 'none',
-		"password" => 'none',
-		"database" => $database,
-		"path" => "/path/to/my/database/file",
-	);
+SSViewer::set_theme('blackcandy');
+SiteTree::enable_nested_urls();
+```
 
-	SSViewer::set_theme('blackcandy');
-	SiteTree::enable_nested_urls();
+Again: make sure that the webserver has permission to read and write to the above path (/path/to/my/database/,
+'file' would be the name of the sqlite db file)
 
-Again: make sure that the webserver has permission to read and write to the above path (/path/to/my/database/, 'file' would be the name of the sqlite db file)
+## URL parameter
 
-URL parameter
--------------
-If you're trying to change a field constrain to NOT NULL on a field that contains NULLs dev/build fails because it might corrupt existing records. In order to perform the action anyway add the URL parameter 'avoidConflict' when running dev/build which temporarily adds a conflict clause to the field spec.
+If you're trying to change a field constrain to NOT NULL on a field that contains NULLs dev/build fails because
+it might corrupt existing records. In order to perform the action anyway add the URL parameter 'avoidConflict' when
+running dev/build which temporarily adds a conflict clause to the field spec.
 E.g.: http://www.my-project.com/?avoidConflict=1
 
-Open Issues
------------
-- SQLite3 is supposed to work with all may not work with certain modules as they are using custom SQL statements passed to the DB class directly ;(
+## Open Issues
+
+- SQLite3 is supposed to work with all may not work with certain modules as they are using custom SQL statements
+  passed to the DB class directly ;(
 - there is no real fulltext search yet and the build-in search engine is not ordering by relevance, check out fts3

--- a/composer.json
+++ b/composer.json
@@ -4,18 +4,21 @@
 	"type": "silverstripe-module",
 	"keywords": ["silverstripe", "sqlite3", "database"],
 	"authors": [
-	{
-		"name": "Ingo Schommer",
-		"email": "ingo@silverstripe.com"
-	},
-	{
-		"name": "Sean Harvey",
-		"email": "sean@silverstripe.com"
-	}
+		{
+			"name": "Ingo Schommer",
+			"email": "ingo@silverstripe.com"
+		},
+		{
+			"name": "Sean Harvey",
+			"email": "sean@silverstripe.com"
+		}
 	],
-
-	"require":
-	{
+	"require": {
 		"silverstripe/framework": "~3.2"
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "1.4.x-dev"
+		}
 	}
 }


### PR DESCRIPTION
Since we prefer users to not use 'dev-master' in composer.json, it's a better idea to give them a version constraint as an alias for this instead.

Docs updated for github markdown format.
