### PR TITLE
BUG SQLite database connection not closed properly

### DIFF
--- a/code/SQLite3Database.php
+++ b/code/SQLite3Database.php
@@ -106,6 +106,12 @@ class SQLite3Database extends SS_Database {
 		return true;
 	}
 
+	public function __destruct() {
+		if($this->dbConn) {
+			$this->dbConn->close();
+		}
+	}
+
 	/**
 	 * Not implemented, needed for PDO
 	 */
@@ -1246,7 +1252,9 @@ class SQLite3Query extends SS_Query {
 	}
 
 	public function __destruct() {
-		if($this->handle) $this->handle->finalize();
+		if($this->handle) {
+			$this->handle->finalize();
+		}
 	}
 
 	public function seek($row) {

--- a/code/SQLitePDODatabase.php
+++ b/code/SQLitePDODatabase.php
@@ -55,6 +55,14 @@ class SQLitePDODatabase extends SQLite3Database {
 		return true;
 	}
 
+	/**
+	 * Overloaded since the parent class tries to call close() on the connection,
+	 * but doing it here won't work as the PDO class has no such method.
+	 */
+	public function __destruct() {
+		// noop
+	}
+
 	public function query($sql, $errorLevel = E_USER_ERROR) {
 
 		if(isset($_REQUEST['previewwrite']) && in_array(strtolower(substr($sql,0,strpos($sql,' '))), array('insert','update','delete','replace'))) {


### PR DESCRIPTION
This was found when performing a load test using HHVM, the sqlite
connections weren't being closed properly so it would throw an
error "Too many open files..." after a number of concurrent
connections were opened.
